### PR TITLE
added get_unused_virtual_fd_from_startfd and corresponding doc

### DIFF
--- a/src/fdtables/docs/get_unused_virtual_fd_from_startfd.md
+++ b/src/fdtables/docs/get_unused_virtual_fd_from_startfd.md
@@ -1,0 +1,24 @@
+Get a virtualfd mapping to put an item into the fdtable.
+
+This function requests an unused virtual FD starting from a specific position, as specified by the arg parameter. It behaves similarly to `get_unused_virtual_fd`, but starts the search at `arg` instead of `0`.
+
+This is intended for use with `fcntl()` commands like `F_DUPFD` and `F_DUPFD_CLOEXEC`
+
+# Panics
+  if the cageid does not exist
+
+# Errors
+  if the cage has used EMFILE virtual descriptors already, return EMFILE
+
+# Example
+```
+# use fdtables::*;
+# let cage_id = threei::TESTING_CAGEID;
+# let underfd: u64 = 10;
+# let fdkind: u32 = 0;
+# let arg: u64 = 2; 
+// Should not error... Ideally the `my_virt_fd` should be 2 in this case
+let my_virt_fd = get_unused_virtual_fd_from_startfd(cage_id, fdkind, underfd, false, 0, arg).unwrap();
+// Check that you get the real fd back here...
+assert_eq!(underfd,translate_virtual_fd(cage_id, my_virt_fd).unwrap().underfd);
+```

--- a/src/fdtables/src/dashmaparrayglobal.rs
+++ b/src/fdtables/src/dashmaparrayglobal.rs
@@ -141,6 +141,47 @@ pub fn get_unused_virtual_fd(
     Err(threei::Errno::EMFILE as u64)
 }
 
+/// This is used to request an unused fd from specific starting position. This is 
+/// similar to `get_unused_virtual_fd` except this function starts from a specific 
+/// starting position mentioned by `arg` arguments. This will be used for `fcntl`.
+#[doc = include_str!("../docs/get_unused_virtual_fd_from_startfd.md")]
+pub fn get_unused_virtual_fd_from_startfd(
+    cageid: u64,
+    fdkind: u32,
+    underfd: u64,
+    should_cloexec: bool,
+    perfdinfo: u64,
+    arg: u64,
+) -> Result<u64, threei::RetVal> {
+
+    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    // Set up the entry so it has the right info...
+    // Note, a HashMap stores its data on the heap!  No need to box it...
+    // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
+    let myentry = FDTableEntry {
+        fdkind,
+        underfd,
+        should_cloexec,
+        perfdinfo,
+    };
+
+    let mut myfdrow = FDTABLE.get_mut(&cageid).unwrap();
+
+    // Check the fds in order.
+    for fdcandidate in arg..FD_PER_PROCESS_MAX {
+        // FIXME: This is likely very slow.  Should do something smarter...
+        if myfdrow[fdcandidate as usize].is_none() {
+            // I just checked.  Should not be there...
+            myfdrow[fdcandidate as usize] = Some(myentry);
+            _increment_fdcount(myentry);
+            return Ok(fdcandidate);
+        }
+    }
+
+    // I must have checked all fds and failed to find one open.  Fail!
+    Err(threei::Errno::EMFILE as u64)
+}
+
 // This is used for things like dup2, which need a specific fd...
 // If the requested_virtualfd is used, I close it...
 #[doc = include_str!("../docs/get_specific_virtual_fd.md")]

--- a/src/fdtables/src/dashmapvecglobal.rs
+++ b/src/fdtables/src/dashmapvecglobal.rs
@@ -95,6 +95,46 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry,
     };
 }
 
+/// This is used to request an unused fd from specific starting position. This is 
+/// similar to `get_unused_virtual_fd` except this function starts from a specific 
+/// starting position mentioned by `arg` arguments. This will be used for `fcntl`.
+#[doc = include_str!("../docs/get_unused_virtual_fd_from_startfd.md")]
+pub fn get_unused_virtual_fd_from_startfd(
+    cageid: u64,
+    fdkind: u32,
+    underfd: u64,
+    should_cloexec: bool,
+    perfdinfo: u64,
+    arg: u64,
+) -> Result<u64, threei::RetVal> {
+
+    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    // Set up the entry so it has the right info...
+    // Note, a HashMap stores its data on the heap!  No need to box it...
+    // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
+    let myentry = FDTableEntry {
+        fdkind,
+        underfd,
+        should_cloexec,
+        perfdinfo,
+    };
+
+    let mut myfdrow = FDTABLE.get_mut(&cageid).unwrap();
+
+    // Check the fds in order.
+    for fdcandidate in arg..FD_PER_PROCESS_MAX {
+        // FIXME: This is likely very slow.  Should do something smarter...
+        if myfdrow[fdcandidate as usize].is_none() {
+            // I just checked.  Should not be there...
+            myfdrow[fdcandidate as usize] = Some(myentry);
+            _increment_fdcount(myentry);
+            return Ok(fdcandidate);
+        }
+    }
+
+    // I must have checked all fds and failed to find one open.  Fail!
+    Err(threei::Errno::EMFILE as u64)
+}
 
 // This is fairly slow if I just iterate sequentially through numbers.
 // However there are not that many to choose from.  I could pop from a list

--- a/src/fdtables/src/muthashmaxglobal.rs
+++ b/src/fdtables/src/muthashmaxglobal.rs
@@ -145,6 +145,47 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<u64, threei::
     };
 }
 
+/// This is used to request an unused fd from specific starting position. This is 
+/// similar to `get_unused_virtual_fd` except this function starts from a specific 
+/// starting position mentioned by `arg` arguments. This will be used for `fcntl`.
+#[doc = include_str!("../docs/get_unused_virtual_fd_from_startfd.md")]
+pub fn get_unused_virtual_fd_from_startfd(
+    cageid: u64,
+    fdkind: u32,
+    underfd: u64,
+    should_cloexec: bool,
+    perfdinfo: u64,
+    arg: u64,
+) -> Result<u64, threei::RetVal> {
+
+    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    // Set up the entry so it has the right info...
+    // Note, a HashMap stores its data on the heap!  No need to box it...
+    // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
+    let myentry = FDTableEntry {
+        fdkind,
+        underfd,
+        should_cloexec,
+        perfdinfo,
+    };
+
+    let mut myfdrow = FDTABLE.get_mut(&cageid).unwrap();
+
+    // Check the fds in order.
+    for fdcandidate in arg..FD_PER_PROCESS_MAX {
+        // FIXME: This is likely very slow.  Should do something smarter...
+        if myfdrow[fdcandidate as usize].is_none() {
+            // I just checked.  Should not be there...
+            myfdrow[fdcandidate as usize] = Some(myentry);
+            _increment_fdcount(myentry);
+            return Ok(fdcandidate);
+        }
+    }
+
+    // I must have checked all fds and failed to find one open.  Fail!
+    Err(threei::Errno::EMFILE as u64)
+}
+
 // This is fairly slow if I just iterate sequentially through numbers.
 // However there are not that many to choose from.  I could pop from a list
 // or a set as well...  Likely the best solution is to keep a count of the

--- a/src/fdtables/src/vanillaglobal.rs
+++ b/src/fdtables/src/vanillaglobal.rs
@@ -127,6 +127,47 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<u64, threei::
     };
 }
 
+/// This is used to request an unused fd from specific starting position. This is 
+/// similar to `get_unused_virtual_fd` except this function starts from a specific 
+/// starting position mentioned by `arg` arguments. This will be used for `fcntl`.
+#[doc = include_str!("../docs/get_unused_virtual_fd_from_startfd.md")]
+pub fn get_unused_virtual_fd_from_startfd(
+    cageid: u64,
+    fdkind: u32,
+    underfd: u64,
+    should_cloexec: bool,
+    perfdinfo: u64,
+    arg: u64,
+) -> Result<u64, threei::RetVal> {
+
+    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    // Set up the entry so it has the right info...
+    // Note, a HashMap stores its data on the heap!  No need to box it...
+    // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
+    let myentry = FDTableEntry {
+        fdkind,
+        underfd,
+        should_cloexec,
+        perfdinfo,
+    };
+
+    let mut myfdrow = FDTABLE.get_mut(&cageid).unwrap();
+
+    // Check the fds in order.
+    for fdcandidate in arg..FD_PER_PROCESS_MAX {
+        // FIXME: This is likely very slow.  Should do something smarter...
+        if myfdrow[fdcandidate as usize].is_none() {
+            // I just checked.  Should not be there...
+            myfdrow[fdcandidate as usize] = Some(myentry);
+            _increment_fdcount(myentry);
+            return Ok(fdcandidate);
+        }
+    }
+
+    // I must have checked all fds and failed to find one open.  Fail!
+    Err(threei::Errno::EMFILE as u64)
+}
+
 // This is fairly slow if I just iterate sequentially through numbers.
 // However there are not that many to choose from.  I could pop from a list
 // or a set as well...  Likely the best solution is to keep a count of the


### PR DESCRIPTION
The original main branch is missing a function named "get_unused_virtual_fd_from_startfd". I have added it to /home/lind/lind-wasm-3i/src/fdtables/src/dashmaparrayglobal.rs. It is also missing an explanation file named get_unused_virtual_fd_from_startfd.md, and I have put it under /home/lind/lind-wasm-3i/src/fdtables/docs.